### PR TITLE
Don't layout hidden views

### DIFF
--- a/Example.playground/Contents.swift
+++ b/Example.playground/Contents.swift
@@ -84,3 +84,16 @@ flexView.addSubview(separator)
 flexView.bounds.size = flexView.sizeThatFits(CGSize(width: 320, height: CGFloat.max))
 
 flexView.renderAsImage()
+
+header.hidden = true
+
+tags.flx_layoutWhenHidden = true
+tags.hidden = true
+
+friends.flx_layoutWhenHidden = true
+friends.hidden = true
+
+flexView.bounds.size = flexView.sizeThatFits(CGSize(width: 320, height: CGFloat.max))
+
+flexView.renderAsImage()
+

--- a/Example.playground/timeline.xctimeline
+++ b/Example.playground/timeline.xctimeline
@@ -27,8 +27,14 @@
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=24&amp;CharacterRangeLoc=2794&amp;EndingColumnNumber=25&amp;EndingLineNumber=85&amp;StartingColumnNumber=1&amp;StartingLineNumber=85&amp;Timestamp=452364186.994639"
+         documentLocation = "#CharacterRangeLen=24&amp;CharacterRangeLoc=2794&amp;EndingColumnNumber=25&amp;EndingLineNumber=85&amp;StartingColumnNumber=1&amp;StartingLineNumber=85&amp;Timestamp=480712542.884963"
          lockedSize = "{350, 832}"
+         selectedRepresentationIndex = "0"
+         shouldTrackSuperviewWidth = "NO">
+      </LoggerValueHistoryTimelineItem>
+      <LoggerValueHistoryTimelineItem
+         documentLocation = "#CharacterRangeLen=24&amp;CharacterRangeLoc=3041&amp;EndingColumnNumber=25&amp;EndingLineNumber=97&amp;StartingColumnNumber=1&amp;StartingLineNumber=97&amp;Timestamp=480714894.888491"
+         lockedSize = "{596, 837}"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/FLXView/FLXView.m
+++ b/FLXView/FLXView.m
@@ -60,6 +60,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSMutableArray *children = [NSMutableArray arrayWithCapacity:self.subviews.count];
     for (UIView *subview in self.subviews) {
+        if (subview.hidden && !subview.flx_layoutWhenHidden)
+            continue;
+        
         [children addObject:[subview flx_generateTree]];
     }
     node.children = children;

--- a/FLXView/UIView+Flex.h
+++ b/FLXView/UIView+Flex.h
@@ -16,6 +16,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readwrite, nonatomic, assign) FLXSelfAlignment flx_selfAlignment;
 
+// Whether this view should take up space in the container FLXView when it's hidden.
+// Default: NO
+//
+@property (readwrite, nonatomic, assign) BOOL flx_layoutWhenHidden;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FLXView/UIView+Flex.m
+++ b/FLXView/UIView+Flex.m
@@ -65,6 +65,20 @@ NS_ASSUME_NONNULL_BEGIN
     [self.superview setNeedsLayout];
 }
 
+- (BOOL)flx_layoutWhenHidden {
+    return [objc_getAssociatedObject(self, @selector(flx_layoutWhenHidden)) boolValue];
+}
+
+- (void)setFlx_layoutWhenHidden:(BOOL)flx_layoutWhenHidden {
+    if (flx_layoutWhenHidden == self.flx_layoutWhenHidden)
+        return;
+
+    objc_setAssociatedObject(self, @selector(flx_layoutWhenHidden), @(flx_layoutWhenHidden), OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    if (self.hidden)
+        [self.superview layoutSubviews];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FLXViewTests/FLXViewTests.m
+++ b/FLXViewTests/FLXViewTests.m
@@ -51,6 +51,53 @@
     XCTAssertEqual(a.frame.size.height, 100);
 }
 
+- (void)testLayoutWithHiddenViews {
+    FLXView *flexView = [[FLXView alloc] init];
+
+    flexView.bounds = CGRectMake(0, 0, 300, 300);
+    flexView.childAlignment = FLXChildAlignmentCenter;
+    flexView.direction = FLXDirectionRow;
+
+    UIView *a = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 100)];
+    a.flx_margins = (FLXMargins){ 0, 10, 0, 10 };
+    a.flx_flex = 60;
+    [flexView addSubview:a];
+
+    UIView *b = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 50)];
+    b.flx_margins = (FLXMargins){ 0, 0, 0, 10 };
+    b.flx_flex = 10;
+    [flexView addSubview:b];
+    b.hidden = YES;
+
+    UIView *c = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 0, 180)];
+    c.flx_margins = (FLXMargins){ 0, 0, 0, 10 };
+    c.flx_flex = 30;
+    [flexView addSubview:c];
+    c.hidden = YES;
+    c.flx_layoutWhenHidden = YES;
+
+    [flexView layoutSubviews];
+
+    XCTAssertEqual(flexView.frame.size.width, 300);
+    XCTAssertEqual(flexView.frame.size.height, 300);
+
+    XCTAssertEqual(a.frame.origin.x, 10);
+    XCTAssertEqual(a.frame.origin.y, 100);
+    XCTAssertEqual(a.frame.size.width, 180);
+    XCTAssertEqual(a.frame.size.height, 100);
+
+    c.flx_layoutWhenHidden = NO;
+    [flexView layoutSubviews];
+
+    XCTAssertEqual(flexView.frame.size.width, 300);
+    XCTAssertEqual(flexView.frame.size.height, 300);
+
+    XCTAssertEqual(a.frame.origin.x, 10);
+    XCTAssertEqual(a.frame.origin.y, 100);
+    XCTAssertEqual(a.frame.size.width, 280);
+    XCTAssertEqual(a.frame.size.height, 100);
+}
+
 - (void)testDefaults {
     FLXView *flexView = [[FLXView alloc] init];
 


### PR DESCRIPTION
With a behavior similar to `UIStackView`, hidden views won't take up space in flex views by default, unless `flx_layoutWhenHidden` property is set to `YES`:

![image](https://cloud.githubusercontent.com/assets/1083228/14066922/eb2689ea-f457-11e5-91fc-a98043b74c76.png)

If we hide the header, and do the same with the `Tags:` and `Friends:` labels, but setting `flx_layoutWhenHidden` to `YES` in them:

![image](https://cloud.githubusercontent.com/assets/1083228/14066927/08a2d0aa-f458-11e5-9b5b-5e48160850d0.png)
